### PR TITLE
Start repo

### DIFF
--- a/azure_img_utils/__init__.py
+++ b/azure_img_utils/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+
+"""azure-img-utils Azure image utilities."""
+
+# Copyright (c) 2021 SUSE LLC. All rights reserved.
+
+__author__ = """SUSE"""
+__email__ = 'public-cloud-dev@susecloud.net'
+__version__ = '0.0.1'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r requirements-test.txt
+
+bumpversion

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,6 @@
+-r requirements.txt
+
+coverage
+flake8
+pytest
+pytest-cov

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+adal
+azure-identity
+azure-mgmt-compute>=17.0.0
+azure-mgmt-resource
+azure-mgmt-storage
+azure-storage-blob>=12.0.0
+requests

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,17 @@
+[bumpversion]
+current_version = 0.0.1
+commit = True
+tag = False
+
+[bumpversion:file:setup.py]
+
+[bumpversion:file:azure_img_utils/__init__.py]
+
+[tool:pytest]
+testpaths = tests
+
+[coverage:report]
+fail_under = 90
+
+[metadata]
+license_file = LICENSE

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,82 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+
+"""Setup script."""
+
+# Copyright (c) 2021 SUSE LLC
+#
+# This file is part of azure_img_utils. azure_img_utils provides an
+# api and command line utilities for handling images in the Azure Cloud.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from setuptools import find_packages, setup
+
+with open('README.md') as readme_file:
+    readme = readme_file.read()
+
+with open('requirements.txt') as req_file:
+    requirements = req_file.read().splitlines()
+
+with open('requirements-test.txt') as req_file:
+    test_requirements = req_file.read().splitlines()[2:]
+
+with open('requirements-dev.txt') as req_file:
+    dev_requirements = test_requirements + req_file.read().splitlines()[2:]
+
+
+setup(
+    name='azure-img-utils',
+    version='0.0.1',
+    description='Package that provides utilities for '
+                'handling images in Azure Cloud.',
+    long_description=readme,
+    long_description_content_type='text/markdown',
+    author='SUSE',
+    author_email='public-cloud-dev@susecloud.net',
+    url='https://github.com/SUSE-Enceladus/azure-img-utils',
+    packages=find_packages(),
+    package_dir={
+        'azure_img_utils': 'azure_img_utils'
+    },
+    entry_points={
+        'console_scripts': [
+            'azure-img-utils=azure_img_utils.azure_cli:main'
+        ]
+    },
+    include_package_data=True,
+    python_requires='>=3.6',
+    install_requires=requirements,
+    extras_require={
+        'dev': dev_requirements,
+        'test': test_requirements
+    },
+    license='GPLv3+',
+    zip_safe=False,
+    keywords='azure-img-utils azure_img_utils',
+    classifiers=[
+        'Development Status :: 4 - Beta',
+        'Environment :: Console',
+        'Intended Audience :: Developers',
+        'Topic :: System :: Software Distribution',
+        'License :: OSI Approved :: '
+        'GNU General Public License v3 or later (GPLv3+)',
+        'Natural Language :: English',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+    ],
+)


### PR DESCRIPTION
Add requirements and setup files.

Is it worth considering a more permissive license than GPLv3? Given this is at the lowest level of the stack if it's GPLv3 it requires anything using it to also be GPLv3 compatible. Given about 2/3rds of Python packages on PYPI use permissive licenses it seems we'd have a better chance of others outside the team using/contributing to the project. Granted we haven't had anyone ask about license change for any other enceladus projects.

Note: I will pull code from Mash as is and reorganize things. Then will make changes/updates afterwards. For example we will want to switch from adal (legacy) to mdal.