### PR TITLE
Migrate storage functions from mash

### DIFF
--- a/azure_img_utils/__init__.py
+++ b/azure_img_utils/__init__.py
@@ -2,7 +2,23 @@
 
 """azure-img-utils Azure image utilities."""
 
-# Copyright (c) 2021 SUSE LLC. All rights reserved.
+# Copyright (c) 2021 SUSE LLC
+#
+# This file is part of azure_img_utils. azure_img_utils provides an
+# api and command line utilities for handling images in the Azure Cloud.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 __author__ = """SUSE"""
 __email__ = 'public-cloud-dev@susecloud.net'

--- a/azure_img_utils/exceptions.py
+++ b/azure_img_utils/exceptions.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+
+"""Azure image utils exceptions module."""
+
+# Copyright (c) 2021 SUSE LLC
+#
+# This file is part of azure_img_utils. azure_img_utils provides an
+# api and command line utilities for handling images in the Azure Cloud.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+class AzureImgUtilsException(Exception):
+    """Generic exception for the azure_img_utils package."""
+
+
+class AzureCloudPartnerException(AzureImgUtilsException):
+    """Exception for Azure Cloud Partner processes."""

--- a/azure_img_utils/filetype.py
+++ b/azure_img_utils/filetype.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2021 SUSE LLC
+#
+# This file is part of azure_img_utils. azure_img_utils provides an
+# api and command line utilities for handling images in the Azure Cloud.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import re
+import lzma
+import subprocess
+
+
+class FileType(object):
+    """
+    map file magic information to type methods
+    """
+    def __init__(self, file_name: str):
+        self.file_name = file_name
+        file_info = subprocess.Popen(
+            ['file', file_name],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE
+        )
+        self.filetype = file_info.communicate()[0].decode()
+
+    def is_xz(self):
+        if re.match('.*: XZ compressed', self.filetype):
+            return True
+        return False
+
+    def get_size(self):
+        if self.is_xz():
+            with lzma.open(self.file_name) as lzma_stream:
+                lzma_stream.seek(0, os.SEEK_END)
+                return lzma_stream.tell()
+        else:
+            return os.path.getsize(self.file_name)

--- a/azure_img_utils/storage.py
+++ b/azure_img_utils/storage.py
@@ -1,0 +1,239 @@
+# Copyright (c) 2021 SUSE LLC
+#
+# This file is part of azure_img_utils. azure_img_utils provides an
+# api and command line utilities for handling images in the Azure Cloud.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import lzma
+
+from azure.mgmt.storage import StorageManagementClient
+from azure.storage.blob import (
+    BlobServiceClient,
+    ContainerSasPermissions
+)
+
+from azure_img_utils.auth import create_sas_token, get_client_from_json
+from azure_img_utils.exceptions import AzureImgUtilsStorageException
+from azure_img_utils.filetype import FileType
+
+
+def delete_blob(
+    credentials: dict,
+    blob: str,
+    container: str,
+    resource_group: str,
+    storage_account: str
+):
+    """
+    Delete page blob in container.
+    """
+    blob_service_client = get_blob_service_with_account_keys(
+        credentials,
+        resource_group,
+        storage_account
+    )
+    container_client = blob_service_client.get_container_client(container)
+    blob_client = container_client.get_blob_client(blob)
+    blob_client.delete_blob()
+
+
+def blob_exists(
+    credentials: dict,
+    blob: str,
+    container: str,
+    resource_group: str,
+    storage_account: str
+):
+    """
+    Return True if blob exists in container.
+    """
+    blob_service_client = get_blob_service_with_account_keys(
+        credentials,
+        resource_group,
+        storage_account
+    )
+    container_client = blob_service_client.get_container_client(container)
+    blob_client = container_client.get_blob_client(blob)
+    return blob_client.exists()
+
+
+def get_blob_url(
+    blob_service,
+    blob_name: str,
+    storage_account: str,
+    container: str,
+    permissions=ContainerSasPermissions(read=True, list=True),
+    expire_hours: int = 1,
+    start_hours: int = 1
+):
+    """
+    Create a URL for the given blob with a shared access signature.
+
+    The signature will expire based on expire_hours.
+    """
+    sas_token = create_sas_token(
+        blob_service,
+        storage_account,
+        container,
+        permissions=permissions,
+        expire_hours=expire_hours,
+        start_hours=start_hours
+    )
+
+    source_blob_url = (
+        'https://{account}.blob.core.windows.net/'
+        '{container}/{blob}?{token}'.format(
+            account=storage_account,
+            container=container,
+            blob=blob_name,
+            token=sas_token
+        )
+    )
+
+    return source_blob_url
+
+
+def get_storage_account_key(
+    credentials: dict,
+    resource_group: str,
+    storage_account: str
+):
+    """Return the first storage account key for the provided account."""
+    storage_client = get_client_from_json(
+        StorageManagementClient,
+        credentials
+    )
+    storage_key_list = storage_client.storage_accounts.list_keys(
+        resource_group,
+        storage_account
+    )
+    return storage_key_list.keys[0].value
+
+
+def get_blob_service_with_account_keys(
+    credentials: dict,
+    resource_group: str,
+    storage_account: str
+):
+    """
+    Return authenticated blob service instance for the storage account.
+
+    Using storage account keys.
+    """
+    account_key = get_storage_account_key(
+        credentials,
+        resource_group,
+        storage_account
+    )
+
+    return BlobServiceClient(
+        account_url='https://{account_name}.blob.core.windows.net'.format(
+            account_name=storage_account
+        ),
+        credential=account_key
+    )
+
+
+def get_blob_service_with_sas_token(
+    storage_account: str,
+    sas_token: str
+):
+    """
+    Return authenticated page blob service instance for the storage account.
+
+    Using an sas token.
+    """
+    return BlobServiceClient(
+        account_url='https://{account_name}.blob.core.windows.net'.format(
+            account_name=storage_account
+        ),
+        credential=sas_token
+    )
+
+
+def upload_azure_file(
+    blob_name: str,
+    container: str,
+    file_name: str,
+    storage_account: str,
+    max_retry_attempts: int = 5,
+    max_workers: int = 5,
+    credentials: dict = None,
+    resource_group: str = None,
+    sas_token: str=None,
+    is_page_blob: bool = False,
+    expand_image: bool = True
+):
+    """
+    Upload file to Azure storage container.
+
+    Authentication can be an sas token or with storage account
+    keys.
+
+    Blob can be block or page and if the blob is an image tarball
+    it can be expanded during upload.
+    """
+    if sas_token:
+        blob_service_client = get_blob_service_with_sas_token(
+            storage_account,
+            sas_token
+        )
+    elif credentials and resource_group:
+        blob_service_client = get_blob_service_with_account_keys(
+            credentials,
+            resource_group,
+            storage_account
+        )
+    else:
+        raise AzureImgUtilsStorageException(
+            'Either an sas_token or credentials and resource_group '
+            ' is required to upload an azure image to a page blob.'
+        )
+
+    container_client = blob_service_client.get_container_client(container)
+    blob_client = container_client.get_blob_client(blob_name)
+
+    if is_page_blob:
+        blob_type = 'PageBlob'
+    else:
+        blob_type = 'BlockBlob'
+
+    system_image_file_type = FileType(file_name)
+    if system_image_file_type.is_xz() and expand_image:
+        open_image = lzma.LZMAFile
+    else:
+        open_image = open
+
+    msg = ''
+    while max_retry_attempts > 0:
+        with open_image(file_name, 'rb') as image_stream:
+            try:
+                blob_client.upload_blob(
+                    image_stream,
+                    blob_type=blob_type,
+                    length=system_image_file_type.get_size(),
+                    max_concurrency=max_workers
+                )
+                return
+            except Exception as error:
+                msg = error
+                max_retry_attempts -= 1
+
+    raise AzureImgUtilsStorageException(
+        'Unable to upload file: {0} to Azure: {1}'.format(
+            file_name,
+            msg
+        )
+    )


### PR DESCRIPTION
All storage functions migrated as is with addition of type annotations. Also, migrated the file type module that allows for uploading compressed tarballs in parts.

Start exceptions module and fix the license content in the init module.