### PR TITLE
Make container and storage account optional

### DIFF
--- a/azure_img_utils/azure_image.py
+++ b/azure_img_utils/azure_image.py
@@ -61,8 +61,8 @@ class AzureImage(object):
 
     def __init__(
         self,
-        container: str,
-        storage_account: str,
+        container: str = None,
+        storage_account: str = None,
         credentials: dict = None,
         credentials_file: str = None,
         resource_group: str = None,
@@ -96,6 +96,11 @@ class AzureImage(object):
 
     def image_blob_exists(self, blob_name: str):
         """Return True if image blob exists in the configured container."""
+        if not self.container:
+            raise AzureImgUtilsException(
+                'Container is required to check if a blob exists'
+            )
+
         return blob_exists(
             self.blob_service_client,
             blob_name,
@@ -104,6 +109,11 @@ class AzureImage(object):
 
     def delete_storage_blob(self, blob_name: str):
         """Delete blob if it exists in the configured container."""
+        if not self.container:
+            raise AzureImgUtilsException(
+                'Container is required to delete a storage blob'
+            )
+
         try:
             delete_blob(
                 self.blob_service_client,
@@ -135,6 +145,11 @@ class AzureImage(object):
         Generate blob name based on image file path if a
         name is not provided.
         """
+        if not self.container:
+            raise AzureImgUtilsException(
+                'Container is required to upload an image blob'
+            )
+
         if not blob_name:
             blob_name = image_file.rsplit(os.sep, maxsplit=1)[-1]
 
@@ -214,9 +229,19 @@ class AzureImage(object):
         If image exists and force replace is True delete
         the existing image before creation.
         """
+        if not self.container:
+            raise AzureImgUtilsException(
+                'Container is required to create a compute image'
+            )
+
         if not self.resource_group:
             raise AzureImgUtilsException(
                 'Resource group is required to create a compute image'
+            )
+
+        if not self.storage_account:
+            raise AzureImgUtilsException(
+                'Storage account is required to create a compute image'
             )
 
         exists = image_exists(self.compute_client, image_name)
@@ -299,6 +324,11 @@ class AzureImage(object):
 
         A blob_url is generated for the container if one is not provided.
         """
+        if not self.container:
+            raise AzureImgUtilsException(
+                'Container is required to add an image to an offer'
+            )
+
         if not blob_url:
             blob_url = get_blob_url(
                 self.blob_service_client,
@@ -431,6 +461,12 @@ class AzureImage(object):
 
         Lazy blob service client initialization.
         """
+        if not self.storage_account:
+            raise AzureImgUtilsException(
+                'Storage account is required to authenticate storage '
+                'blob operations.'
+            )
+
         if not self._blob_service_client:
             if self.sas_token:
                 args = (

--- a/azure_img_utils/azure_image.py
+++ b/azure_img_utils/azure_image.py
@@ -96,11 +96,6 @@ class AzureImage(object):
 
     def image_blob_exists(self, blob_name: str):
         """Return True if image blob exists in the configured container."""
-        if not self.container:
-            raise AzureImgUtilsException(
-                'Container is required to check if a blob exists'
-            )
-
         return blob_exists(
             self.blob_service_client,
             blob_name,
@@ -109,11 +104,6 @@ class AzureImage(object):
 
     def delete_storage_blob(self, blob_name: str):
         """Delete blob if it exists in the configured container."""
-        if not self.container:
-            raise AzureImgUtilsException(
-                'Container is required to delete a storage blob'
-            )
-
         try:
             delete_blob(
                 self.blob_service_client,
@@ -145,11 +135,6 @@ class AzureImage(object):
         Generate blob name based on image file path if a
         name is not provided.
         """
-        if not self.container:
-            raise AzureImgUtilsException(
-                'Container is required to upload an image blob'
-            )
-
         if not blob_name:
             blob_name = image_file.rsplit(os.sep, maxsplit=1)[-1]
 

--- a/azure_img_utils/storage.py
+++ b/azure_img_utils/storage.py
@@ -110,8 +110,13 @@ def get_storage_account_key(
 
 def get_blob_client(blob_service_client, blob_name: str, container: str):
     """Return blob client based on container and blob name."""
-    container_client = blob_service_client.get_container_client(container)
-    return container_client.get_blob_client(blob_name)
+    try:
+        container_client = blob_service_client.get_container_client(container)
+        blob_client = container_client.get_blob_client(blob_name)
+    except ValueError as error:
+        raise AzureImgUtilsStorageException(error) from error
+
+    return blob_client
 
 
 @singledispatch


### PR DESCRIPTION
For AzureImage class creation. These are not required when doing
MPC actions. Instead validate required args in methods where they
are required.