### PR TITLE
Offer management related functions class refactor

### DIFF
--- a/azure_img_utils/azure_image.py
+++ b/azure_img_utils/azure_image.py
@@ -546,7 +546,6 @@ class AzureImage(object):
             sku,
             **kwargs
         )
-
         self.upload_offer_doc(
             offer_id,
             publisher_id,

--- a/azure_img_utils/azure_image.py
+++ b/azure_img_utils/azure_image.py
@@ -55,7 +55,6 @@ from azure_img_utils.cloud_partner import (
     add_image_version_to_offer,
     get_cloud_partner_api_headers,
     get_cloud_partner_endpoint,
-    get_cloud_partner_operation,
     process_request,
     remove_image_version_from_offer
 )
@@ -688,7 +687,17 @@ class AzureImage(object):
         """
         Returns a dictionary status for the given operation.
         """
-        return get_cloud_partner_operation(self.access_token, operation)
+        endpoint = 'https://cloudpartner.azure.com{operation}'.format(
+            operation=operation
+        )
+
+        headers = get_cloud_partner_api_headers(self.access_token)
+        response = process_request(
+            endpoint,
+            headers
+        )
+
+        return response
 
     @property
     def blob_service_client(self):

--- a/azure_img_utils/azure_image.py
+++ b/azure_img_utils/azure_image.py
@@ -51,12 +51,11 @@ from azure_img_utils.compute import (
 )
 
 from azure_img_utils.cloud_partner import (
+    add_image_version_to_offer,
     get_cloud_partner_api_headers,
     get_cloud_partner_offer_status,
     get_cloud_partner_endpoint,
     get_cloud_partner_operation,
-    request_cloud_partner_offer_doc,
-    add_image_version_to_offer,
     process_request,
     remove_image_version_from_offer
 )
@@ -449,11 +448,19 @@ class AzureImage(object):
         """
         Return the offer doc dictionary for the given offer.
         """
-        return request_cloud_partner_offer_doc(
-            self.access_token,
+        endpoint = get_cloud_partner_endpoint(
             offer_id,
             publisher_id
         )
+
+        headers = get_cloud_partner_api_headers(self.access_token)
+
+        response = process_request(
+            endpoint,
+            headers,
+            method='get'
+        )
+        return response
 
     def upload_offer_doc(
         self,
@@ -540,6 +547,7 @@ class AzureImage(object):
             sku,
             **kwargs
         )
+
         self.upload_offer_doc(
             offer_id,
             publisher_id,

--- a/azure_img_utils/azure_image.py
+++ b/azure_img_utils/azure_image.py
@@ -57,7 +57,6 @@ from azure_img_utils.cloud_partner import (
     get_cloud_partner_operation,
     request_cloud_partner_offer_doc,
     add_image_version_to_offer,
-    put_cloud_partner_offer_doc,
     process_request,
     remove_image_version_from_offer
 )
@@ -467,11 +466,21 @@ class AzureImage(object):
 
         offer_doc is a dictionary defining the offer details.
         """
-        put_cloud_partner_offer_doc(
-            self.access_token,
-            offer_doc,
+        endpoint = get_cloud_partner_endpoint(
             offer_id,
             publisher_id
+        )
+        headers = get_cloud_partner_api_headers(
+            self.access_token,
+            content_type='application/json',
+            if_match='*'
+        )
+
+        process_request(
+            endpoint,
+            headers,
+            data=offer_doc,
+            method='put'
         )
 
     def add_image_to_offer(

--- a/azure_img_utils/azure_image.py
+++ b/azure_img_utils/azure_image.py
@@ -51,12 +51,14 @@ from azure_img_utils.compute import (
 )
 
 from azure_img_utils.cloud_partner import (
+    get_cloud_partner_api_headers,
     get_cloud_partner_offer_status,
+    get_cloud_partner_endpoint,
     get_cloud_partner_operation,
     request_cloud_partner_offer_doc,
     add_image_version_to_offer,
     put_cloud_partner_offer_doc,
-    publish_cloud_partner_offer,
+    process_request,
     go_live_with_cloud_partner_offer,
     remove_image_version_from_offer
 )
@@ -585,12 +587,26 @@ class AzureImage(object):
 
         Returns the operation uri.
         """
-        return publish_cloud_partner_offer(
-            self.access_token,
+        endpoint = get_cloud_partner_endpoint(
             offer_id,
             publisher_id,
-            notification_emails
+            publish=True
         )
+
+        headers = get_cloud_partner_api_headers(
+            self.access_token,
+            content_type='application/json'
+        )
+
+        response = process_request(
+            endpoint,
+            headers,
+            data={'metadata': {'notification-emails': notification_emails}},
+            method='post',
+            json_response=False
+        )
+
+        return response.headers['Location']
 
     def go_live_with_offer(
         self,

--- a/azure_img_utils/azure_image.py
+++ b/azure_img_utils/azure_image.py
@@ -677,8 +677,8 @@ class AzureImage(object):
                 "steps[?stepName=='publisher-signoff'].status | [0]",
                 response
             )
-        if signoff_status == 'waitingForPublisherReview':
-            status = 'waitingForPublisherReview'
+            if signoff_status == 'waitingForPublisherReview':
+                status = 'waitingForPublisherReview'
 
         return status
 

--- a/azure_img_utils/azure_image.py
+++ b/azure_img_utils/azure_image.py
@@ -59,7 +59,6 @@ from azure_img_utils.cloud_partner import (
     add_image_version_to_offer,
     put_cloud_partner_offer_doc,
     process_request,
-    go_live_with_cloud_partner_offer,
     remove_image_version_from_offer
 )
 
@@ -620,11 +619,24 @@ class AzureImage(object):
 
         Returns the operation uri.
         """
-        return go_live_with_cloud_partner_offer(
-            self.access_token,
+        endpoint = get_cloud_partner_endpoint(
             offer_id,
-            publisher_id
+            publisher_id,
+            go_live=True
         )
+        headers = get_cloud_partner_api_headers(
+            self.access_token,
+            content_type='application/json'
+        )
+
+        response = process_request(
+            endpoint,
+            headers,
+            method='post',
+            json_response=False
+        )
+
+        return response.headers['Location']
 
     def get_offer_status(self, offer_id, publisher_id) -> str:
         """

--- a/azure_img_utils/cli/offer.py
+++ b/azure_img_utils/cli/offer.py
@@ -78,8 +78,7 @@ def publish(
             log_level=config_data.log_level,
             log_callback=logger
         )
-        operation_uri = az_img.publish_cloud_partner_offer(
-            az_img.access_token,
+        operation_uri = az_img.publish_offer(
             offer_id,
             config_data.publisher_id,
             config_data.notification_emails

--- a/azure_img_utils/cloud_partner.py
+++ b/azure_img_utils/cloud_partner.py
@@ -89,23 +89,6 @@ def get_cloud_partner_api_headers(
     return headers
 
 
-def get_cloud_partner_operation(access_token: str, operation: str) -> dict:
-    """
-    Get the status of the provided API operation.
-    """
-    endpoint = 'https://cloudpartner.azure.com{operation}'.format(
-        operation=operation
-    )
-
-    headers = get_cloud_partner_api_headers(access_token)
-    response = process_request(
-        endpoint,
-        headers
-    )
-
-    return response
-
-
 def process_request(
     endpoint: str,
     headers: dict,

--- a/azure_img_utils/cloud_partner.py
+++ b/azure_img_utils/cloud_partner.py
@@ -28,34 +28,6 @@ from datetime import date, datetime
 from azure_img_utils.exceptions import AzureCloudPartnerException
 
 
-def go_live_with_cloud_partner_offer(
-    access_token: str,
-    offer_id: str,
-    publisher_id: str
-) -> str:
-    """
-    Go live with cloud partner offer and return the operation location.
-    """
-    endpoint = get_cloud_partner_endpoint(
-        offer_id,
-        publisher_id,
-        go_live=True
-    )
-    headers = get_cloud_partner_api_headers(
-        access_token,
-        content_type='application/json'
-    )
-
-    response = process_request(
-        endpoint,
-        headers,
-        method='post',
-        json_response=False
-    )
-
-    return response.headers['Location']
-
-
 def get_cloud_partner_endpoint(
     offer_id: str,
     publisher_id: str,

--- a/azure_img_utils/cloud_partner.py
+++ b/azure_img_utils/cloud_partner.py
@@ -17,7 +17,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import copy
-import jmespath
 import json
 import re
 import requests
@@ -158,68 +157,6 @@ def process_request(
         return response.json()
     else:
         return response
-
-
-def request_cloud_partner_offer_doc(
-    access_token: str,
-    offer_id: str,
-    publisher_id: str
-) -> dict:
-    """
-    Request a Cloud Partner Offer doc for the provided publisher and offer.
-    """
-    endpoint = get_cloud_partner_endpoint(
-        offer_id,
-        publisher_id
-    )
-    headers = get_cloud_partner_api_headers(access_token)
-
-    response = process_request(
-        endpoint,
-        headers,
-        method='get'
-    )
-
-    return response
-
-
-def get_cloud_partner_offer_status(
-    access_token: str,
-    offer_id: str,
-    publisher_id: str
-) -> dict:
-    """
-    Returns the status of a Cloud Partner Offer based on id and publisher.
-
-    If status is not found "unkown" is returned. If offer is publishing
-    and publisher-signoff step is waitingForPublisherReview then this
-    is the offer status. The offer is waiting for publisher to trigger
-    go-live.
-    """
-    endpoint = get_cloud_partner_endpoint(
-        offer_id,
-        publisher_id,
-        status=True
-    )
-    headers = get_cloud_partner_api_headers(access_token)
-
-    response = process_request(
-        endpoint,
-        headers,
-        method='get'
-    )
-
-    status = response.get('status', 'unkown')
-
-    if status == 'running':
-        signoff_status = jmespath.search(
-            "steps[?stepName=='publisher-signoff'].status | [0]",
-            response
-        )
-        if signoff_status == 'waitingForPublisherReview':
-            status = 'waitingForPublisherReview'
-
-    return status
 
 
 def add_image_version_to_offer(

--- a/azure_img_utils/cloud_partner.py
+++ b/azure_img_utils/cloud_partner.py
@@ -164,36 +164,6 @@ def put_cloud_partner_offer_doc(
     return response
 
 
-def publish_cloud_partner_offer(
-    access_token: str,
-    offer_id: str,
-    publisher_id: str,
-    notification_emails: str
-):
-    """
-    Publish the cloud partner offer and return the operation location.
-    """
-    endpoint = get_cloud_partner_endpoint(
-        offer_id,
-        publisher_id,
-        publish=True
-    )
-    headers = get_cloud_partner_api_headers(
-        access_token,
-        content_type='application/json'
-    )
-
-    response = process_request(
-        endpoint,
-        headers,
-        data={'metadata': {'notification-emails': notification_emails}},
-        method='post',
-        json_response=False
-    )
-
-    return response.headers['Location']
-
-
 def process_request(
     endpoint: str,
     headers: dict,

--- a/azure_img_utils/cloud_partner.py
+++ b/azure_img_utils/cloud_partner.py
@@ -107,35 +107,6 @@ def get_cloud_partner_operation(access_token: str, operation: str) -> dict:
     return response
 
 
-def put_cloud_partner_offer_doc(
-    access_token: str,
-    doc: dict,
-    offer_id: str,
-    publisher_id: str
-):
-    """
-    Put an updated cloud partner offer doc to the API.
-    """
-    endpoint = get_cloud_partner_endpoint(
-        offer_id,
-        publisher_id
-    )
-    headers = get_cloud_partner_api_headers(
-        access_token,
-        content_type='application/json',
-        if_match='*'
-    )
-
-    response = process_request(
-        endpoint,
-        headers,
-        data=doc,
-        method='put'
-    )
-
-    return response
-
-
 def process_request(
     endpoint: str,
     headers: dict,

--- a/tests/test_azure_auth.py
+++ b/tests/test_azure_auth.py
@@ -1,0 +1,60 @@
+import pytest
+
+from unittest.mock import MagicMock, patch
+
+from azure_img_utils.auth import (
+   acquire_access_token,
+)
+
+from azure_img_utils.exceptions import (
+    AzureImgUtilsException
+)
+
+
+class TestAzureAuth(object):
+    def setup_class(self):
+        pass
+
+    @patch('azure_img_utils.auth.msal.ConfidentialClientApplication')
+    def test_acquire_access_token(self, mock_cclient_app):
+
+        my_credentials = {
+            'clientId': 'myClientId',
+            'clientSecret': 'myClientSecret',
+            'activeDirectoryEndpointUrl': 'myADEndpointUrl',
+            'managementEndpointUrl': 'myMgmtEndpointUrl',
+            'tenantId': 'myTenantId'
+        }
+
+        my_client = MagicMock()
+
+        my_response = {
+            'access_token': 'mySecretAccessToken'
+        }
+
+        my_client.acquire_token_for_client.return_value = my_response
+        mock_cclient_app.return_value = my_client
+
+        my_token = acquire_access_token(
+            my_credentials,
+            cloud_partner=False
+        )
+        assert my_token == 'mySecretAccessToken'
+
+        # Error condidion
+        my_err_response = {
+            'access_token': 'mySecretAccessToken',
+            'error': 'myCustomError'
+        }
+
+        my_client.acquire_token_for_client.return_value = my_err_response
+
+        msg = 'Unable to authenticate against ' \
+              'https://cloudpartner.azure.com/.default: ' \
+              'myCustomError'
+
+        with pytest.raises(AzureImgUtilsException, match=msg):
+            my_token = acquire_access_token(
+                my_credentials,
+                cloud_partner=True
+            )

--- a/tests/test_azure_cloud_partner.py
+++ b/tests/test_azure_cloud_partner.py
@@ -106,7 +106,7 @@ class TestAzureCloudPartner(object):
         operation = self.image.publish_offer('sles', 'suse', 'test@email.com')
         assert operation == '/uri/to/operation/id'
 
-    @patch('azure_img_utils.cloud_partner.process_request')
+    @patch('azure_img_utils.azure_image.process_request')
     def test_go_live_with_offer(self, mock_process_request):
         response = MagicMock(spec=Response)
         response.headers = {'Location': '/uri/to/operation/id'}

--- a/tests/test_azure_cloud_partner.py
+++ b/tests/test_azure_cloud_partner.py
@@ -16,7 +16,7 @@ class TestAzureCloudPartner(object):
         # Mock access token
         self.image._access_token = 'supersecret'
 
-    @patch('azure_img_utils.cloud_partner.process_request')
+    @patch('azure_img_utils.azure_image.process_request')
     def test_get_offer_doc(self, mock_process_request):
         mock_process_request.return_value = {'offer': 'doc'}
         doc = self.image.get_offer_doc('sles', 'suse')
@@ -29,8 +29,8 @@ class TestAzureCloudPartner(object):
         self.image.upload_offer_doc('sles', 'suse', doc)
 
     @patch('azure_img_utils.azure_image.process_request')
-    # @patch('azure_img_utils.cloud_partner.process_request')
-    def test_add_image_to_offer(self, mock_process_request):
+    @patch('azure_img_utils.cloud_partner.process_request')
+    def test_add_image_to_offer(self, mock_process_request, mock_preq2):
         doc = {
             'definition': {
                 'plans': [
@@ -43,6 +43,8 @@ class TestAzureCloudPartner(object):
         }
 
         mock_process_request.return_value = doc
+        mock_preq2.return_value = doc
+
         self.image.add_image_to_offer(
             'image.raw',
             'image123-v20111111',
@@ -51,9 +53,9 @@ class TestAzureCloudPartner(object):
             'suse',
             'suse-sles',
             'gen1',
-            'bloburl',
-            'image-gen2',
-            'gen2'
+            blob_url='bloburl',
+            generation_id='image-gen2',
+            generation_suffix='gen2'
         )
 
         vm_key = 'microsoft-azure-corevm.vmImagesPublicAzure'
@@ -64,8 +66,9 @@ class TestAzureCloudPartner(object):
         assert generation['mediaName'] == 'image123-v20111111-gen2'
         assert generation['showInGui']
 
+    @patch('azure_img_utils.azure_image.process_request')
     @patch('azure_img_utils.cloud_partner.process_request')
-    def test_remove_image_from_offer(self, mock_process_request):
+    def test_remove_image_from_offer(self, mock_process_request, mock_preq2):
         vm_key = 'microsoft-azure-corevm.vmImagesPublicAzure'
         doc = {
             'definition': {
@@ -89,6 +92,7 @@ class TestAzureCloudPartner(object):
         }
 
         mock_process_request.return_value = doc
+        mock_preq2.return_value = doc
         self.image.remove_image_from_offer('suse:sles:gen1:2011.11.11')
         self.image.remove_image_from_offer('suse:sles:gen2:2011.11.11')
 

--- a/tests/test_azure_cloud_partner.py
+++ b/tests/test_azure_cloud_partner.py
@@ -134,7 +134,7 @@ class TestAzureCloudPartner(object):
         status = self.image.get_offer_status('sles', 'suse')
         assert status == 'waitingForPublisherReview'
 
-    @patch('azure_img_utils.cloud_partner.process_request')
+    @patch('azure_img_utils.azure_image.process_request')
     def test_get_operation(self, mock_process_request):
         mock_process_request.return_value = {'operation': 'info'}
         operation = self.image.get_operation('/uri/to/operation/id')

--- a/tests/test_azure_cloud_partner.py
+++ b/tests/test_azure_cloud_partner.py
@@ -22,12 +22,14 @@ class TestAzureCloudPartner(object):
         doc = self.image.get_offer_doc('sles', 'suse')
         assert doc['offer'] == 'doc'
 
-    @patch('azure_img_utils.cloud_partner.process_request')
+    @patch('azure_img_utils.azure_image.process_request')
     def test_upload_offer_doc(self, mock_process_request):
+        mock_process_request.return_value = {'offer': 'doc'}
         doc = {'offer': 'doc'}
         self.image.upload_offer_doc('sles', 'suse', doc)
 
-    @patch('azure_img_utils.cloud_partner.process_request')
+    @patch('azure_img_utils.azure_image.process_request')
+    # @patch('azure_img_utils.cloud_partner.process_request')
     def test_add_image_to_offer(self, mock_process_request):
         doc = {
             'definition': {

--- a/tests/test_azure_cloud_partner.py
+++ b/tests/test_azure_cloud_partner.py
@@ -121,7 +121,7 @@ class TestAzureCloudPartner(object):
         operation = self.image.go_live_with_offer('sles', 'suse')
         assert operation == '/uri/to/operation/id'
 
-    @patch('azure_img_utils.cloud_partner.process_request')
+    @patch('azure_img_utils.azure_image.process_request')
     def test_get_offer_status(self, mock_process_request):
         mock_process_request.return_value = {
             'status': 'running',

--- a/tests/test_azure_cloud_partner.py
+++ b/tests/test_azure_cloud_partner.py
@@ -96,8 +96,9 @@ class TestAzureCloudPartner(object):
         assert '2011.11.11' not in plan[vm_key]
         assert '2011.11.11' not in generations
 
-    @patch('azure_img_utils.cloud_partner.process_request')
+    @patch('azure_img_utils.azure_image.process_request')
     def test_publish_offer(self, mock_process_request):
+
         response = MagicMock(spec=Response)
         response.headers = {'Location': '/uri/to/operation/id'}
         mock_process_request.return_value = response

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1228,7 +1228,7 @@ def test_cloud_partner_offer_publish_ok(azure_image_mock):
 
     myUrl = "https://mytest.com/locationURL"
     image_class = MagicMock()
-    image_class.publish_cloud_partner_offer.return_value = myUrl
+    image_class.publish_offer.return_value = myUrl
     azure_image_mock.return_value = image_class
 
     args = [
@@ -1255,7 +1255,7 @@ def test_cloud_partner_offer_publish_offer_id_not_provided(
 
     myUrl = "https://mytest.com/locationURL"
     image_class = MagicMock()
-    image_class.publish_cloud_partner_offer.return_value = myUrl
+    image_class.publish_offer.return_value = myUrl
     azure_image_mock.return_value = image_class
 
     args = [
@@ -1280,7 +1280,7 @@ def test_cloud_partner_offer_publish_exc(azure_image_mock):
         raise Exception('myException')
 
     image_class = MagicMock()
-    image_class.publish_cloud_partner_offer.side_effect = my_side_eff
+    image_class.publish_offer.side_effect = my_side_eff
     azure_image_mock.return_value = image_class
 
     args = [


### PR DESCRIPTION
# Changes
- Refactor for the following class functions:
  - get_offer_doc
  - upload_offer_doc
  - publish_offer
  - go_live_with_offer
  - get_offer_status
  - get_operation

- Fixed CLI offer subcommand, as it was calling the imported function instead the class one. Fixed CLI tests accordingly.

# Remarks
- Left untouched add_image_to_offer and remove_image_from_offer functions, as the only part that could be 'unrolled' would be the offer_doc management part and I think it's better to have that encapsulated in those fns.