### PR TITLE
Raise Exception in publish offer operation if notification_emails param is not provided

### DIFF
--- a/azure_img_utils/azure_image.py
+++ b/azure_img_utils/azure_image.py
@@ -601,6 +601,10 @@ class AzureImage(object):
 
         Returns the operation uri.
         """
+        if not notification_emails:
+            msg = 'notification_emails parameter is required for publish'
+            raise AzureImgUtilsException(msg)
+
         endpoint = get_cloud_partner_endpoint(
             offer_id,
             publisher_id,

--- a/tests/test_azure_cloud_partner.py
+++ b/tests/test_azure_cloud_partner.py
@@ -8,6 +8,7 @@ from azure_img_utils.azure_image import AzureImage
 from azure_img_utils.cloud_partner import deprecate_image_in_offer_doc
 
 from azure_img_utils.exceptions import (
+    AzureImgUtilsException,
     AzureCloudPartnerException
 )
 
@@ -163,6 +164,12 @@ class TestAzureCloudPartner(object):
 
         operation = self.image.publish_offer('sles', 'suse', 'test@email.com')
         assert operation == '/uri/to/operation/id'
+
+    def test_publish_offer_exception(self):
+        msg = 'notification_emails parameter is required for publish'
+
+        with pytest.raises(AzureImgUtilsException, match=msg):
+            self.image.publish_offer('sles', 'suse', '')
 
     @patch('azure_img_utils.azure_image.process_request')
     def test_go_live_with_offer(self, mock_process_request):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1299,6 +1299,27 @@ def test_cloud_partner_offer_publish_exc(azure_image_mock):
     assert "myException" in result.output
 
 
+def test_cloud_partner_offer_publish_exc_notif():
+    """Confirm cloud partner offer publish exception handling is ok
+    when notification_emails is not provided.
+    """
+
+    args = [
+        'cloud-partner-offer', 'publish',
+        '--credentials-file', 'tests/creds.json',
+        '--offer-id', 'myOfferId',
+        '--publisher-id', 'myPublisherId',
+        '--no-color'
+    ]
+
+    runner = CliRunner()
+    result = runner.invoke(az_img_utils, args)
+    assert result.exit_code == 1
+    assert "Unable to publish cloud partner offer" in result.output
+    assert "notification_emails parameter is required for publish" \
+        in result.output
+
+
 # -------------------------------------------------
 # cloud-partner-offer publish tests
 @patch('azure_img_utils.cli.offer.AzureImage')


### PR DESCRIPTION
In the publish operation, Azure API does not provide useful feedback if a offer publish operation is attempted without providing the **notification_emails** parameter (see #47 )

This change includes the logic to raise the exception with a meaningful error message in this scenario
