### PR TITLE
Do not delete version if no other versions exist

### DIFF
--- a/azure_img_utils/cloud_partner.py
+++ b/azure_img_utils/cloud_partner.py
@@ -230,12 +230,26 @@ def remove_image_version_from_offer(
     for doc_sku in doc['definition']['plans']:
         if doc_sku['planId'] == plan_id:
             if image_version in doc_sku[vm_images_key]:
+                if len(doc_sku[vm_images_key].keys()) == 1:
+                    raise AzureCloudPartnerException(
+                        f'Unable to remove {image_version} from {plan_id}. '
+                        'This is the last version in the plan. '
+                        'Please deprecate the offer or plan instead.'
+                    )
+
                 del doc_sku[vm_images_key][image_version]
                 removed = True
 
         for plan in doc_sku['diskGenerations']:
             if plan['planId'] == plan_id:
                 if image_version in plan[vm_images_key]:
+                    if len(doc_sku[vm_images_key].keys()) == 1:
+                        raise AzureCloudPartnerException(
+                            f'Unable to remove {image_version} from {plan_id}'
+                            '. This is the last version in the plan. '
+                            'Please deprecate the offer or plan instead.'
+                        )
+
                     del plan[vm_images_key][image_version]
                     removed = True
 


### PR DESCRIPTION
In the case that the version being deleted is the last version in a plan the plan or offer needs to be deprecated. This process can only be done currently through dashboard and must be done manually.