### PR TITLE
Fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ Per Azure documentation:
 > An Azure service principal is an identity created for use with applications,
 > hosted services, and automated tools to access Azure resources.
 
-[Here](https://docs.microsoft.com/en-us/cli/azure/create-an-azure-service-principal
--azure-cli) you can find how to create a service principal with the azure cli.
+[Here](https://docs.microsoft.com/en-us/cli/azure/create-an-azure-service-principal-azure-cli)
+you can find how to create a service principal with the azure cli.
 
 With your subscriptionId, the resourceGroupId and the required permissions, you can
 create the service principal with the following command:


### PR DESCRIPTION
The line-break to the create azure service principal link breaks the underlying link. This commit removes the line break and fixes the displayed link in the README file.