### PR TITLE
Add config dir override

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1327,6 +1327,7 @@ def test_cloud_partner_offer_publish_exc_notif():
     args = [
         'cloud-partner-offer', 'publish',
         '--credentials-file', 'tests/creds.json',
+        '--config-dir', './tests',
         '--offer-id', 'myOfferId',
         '--publisher-id', 'myPublisherId',
         '--no-color'


### PR DESCRIPTION
This prevents erroneous test failure when a valid config exists in the default config dir on the test machine.