### PR TITLE
Migrate to new arg name

### DIFF
--- a/azure_img_utils/compute.py
+++ b/azure_img_utils/compute.py
@@ -50,10 +50,10 @@ def create_gallery_image_definition_version(
         'storage_profile': {
             'os_disk_image': {
                 'source': {
-                    'id': f'/subscriptions/{subscription_id}/'
-                          f'resourceGroups/{resource_group}/'
-                          'providers/Microsoft.Storage/'
-                          f'storageAccounts/{storage_account}',
+                    'storageAccountId': f'/subscriptions/{subscription_id}/'
+                                        f'resourceGroups/{resource_group}/'
+                                        'providers/Microsoft.Storage/'
+                                        f'storageAccounts/{storage_account}',
                     'uri': f'https://{storage_account}.blob.core.windows.net/'
                            f'{container}/{blob_name}'
                 },


### PR DESCRIPTION
MS sent an email stating the "id" field would be going away and replaced by "storageAccountId":

> 2. If you use blobs as source to create ACG Image versions:
> 
> If you're using the old property ‘[properties.storageProfile.[osDiskImage/dataDiskImages].source.Id,‘](https://learn.microsoft.com/rest/api/compute/gallery-image-versions/create-or-update?view=rest-compute-2023-10-02&%253Btabs=HTTP&tabs=HTTP#gallerydiskimagesource) you should move to the property ’[properties.storageProfile.osDiskImage.source.storageAccountId’](https://learn.microsoft.com/rest/api/compute/gallery-image-versions/create-or-update?view=rest-compute-2023-10-02&%3Btabs=HTTP&tabs=HTTP#gallerydiskimagesource). This property requires minimum api-version 2022-03-03.
> Ensure that the identity (users/service principal, etc.) creating the Image has the Storage Account Contributor or ‘Microsoft.Storage/storageAccounts/listKeys/action’.

This is noted in documentation: https://learn.microsoft.com/en-us/rest/api/compute/gallery-image-versions/create-or-update?view=rest-compute-2023-10-02&%3Btabs=HTTP&tabs=HTTP#gallerydiskimagesource

We need to confirm that the version of SDK has the required API version.