### PR TITLE
Carving out the `get_offer` function to a utils file to minimize code duplication

### DIFF
--- a/azure_img_utils/azure_container.py
+++ b/azure_img_utils/azure_container.py
@@ -32,10 +32,7 @@ from azure_img_utils.exceptions import (
 )
 
 from azure_img_utils.cloud_partner import (
-    get_cloud_partner_api_headers,
-    get_resource_endpoint,
-    process_request,
-    get_durable_id
+    get_offer_doc
 )
 
 
@@ -92,16 +89,12 @@ class AzureContainer(object):
         """
         Return the offer doc dictionary for the given offer.
         """
-        headers = get_cloud_partner_api_headers(self.access_token)
-        durable_id = '/'.join(['product', get_durable_id(headers, offer_id)])
-        endpoint = get_resource_endpoint(durable_id, target_type)
-        response = process_request(
-            endpoint,
-            headers,
-            method='get',
-            retries=retries
+        return get_offer_doc(
+            self.access_token,
+            offer_id,
+            target_type,
+            retries
         )
-        return response
 
     @property
     def credentials(self):

--- a/azure_img_utils/azure_image.py
+++ b/azure_img_utils/azure_image.py
@@ -56,14 +56,14 @@ from azure_img_utils.compute import (
 from azure_img_utils.cloud_partner import (
     add_image_version_to_offer,
     get_cloud_partner_api_headers,
-    get_resource_endpoint,
     process_request,
     get_durable_id,
     INGESTION_API,
     get_offer_submissions,
     deprecate_image_in_offer_doc,
     submit_configure_request,
-    get_technical_details
+    get_technical_details,
+    get_offer_doc
 )
 
 
@@ -469,17 +469,12 @@ class AzureImage(object):
         """
         Return the offer doc dictionary for the given offer.
         """
-        headers = get_cloud_partner_api_headers(self.access_token)
-        durable_id = '/'.join(['product', get_durable_id(headers, offer_id)])
-        endpoint = get_resource_endpoint(durable_id, target_type)
-
-        response = process_request(
-            endpoint,
-            headers,
-            method='get',
-            retries=retries
+        return get_offer_doc(
+            self.access_token,
+            offer_id,
+            target_type,
+            retries
         )
-        return response
 
     def submit_request(
         self,

--- a/azure_img_utils/cloud_partner.py
+++ b/azure_img_utils/cloud_partner.py
@@ -309,3 +309,24 @@ def submit_configure_request(
     )
 
     return response['jobId']
+
+
+def get_offer_doc(
+    access_token: str,
+    offer_id: str,
+    target_type: str = 'draft',
+    retries: int = 5
+) -> dict:
+    """
+    Returns the offer doc dictionary for the given offer.
+    """
+    headers = get_cloud_partner_api_headers(access_token)
+    durable_id = '/'.join(['product', get_durable_id(headers, offer_id)])
+    endpoint = get_resource_endpoint(durable_id, target_type)
+    response = process_request(
+        endpoint,
+        headers,
+        method='get',
+        retries=retries
+    )
+    return response

--- a/tests/test_azure_cloud_partner.py
+++ b/tests/test_azure_cloud_partner.py
@@ -30,8 +30,8 @@ class TestAzureCloudPartner(object):
     def inject_fixtures(self, caplog):
         self._caplog = caplog
 
-    @patch('azure_img_utils.azure_image.get_durable_id')
-    @patch('azure_img_utils.azure_image.process_request')
+    @patch('azure_img_utils.cloud_partner.get_durable_id')
+    @patch('azure_img_utils.cloud_partner.process_request')
     def test_get_offer_doc(self, mock_process_request, mock_get_durable_id):
         mock_process_request.return_value = {'offer': 'doc'}
         mock_get_durable_id.return_value = '123456789'
@@ -72,12 +72,12 @@ class TestAzureCloudPartner(object):
 
     @patch.object(AzureImage, 'wait_on_operation')
     @patch('azure_img_utils.azure_image.submit_configure_request')
-    @patch('azure_img_utils.azure_image.process_request')
+    @patch('azure_img_utils.azure_image.get_offer_doc')
     @patch('azure_img_utils.cloud_partner.process_request')
     def test_add_image_to_offer(
         self,
         mock_process_request,
-        mock_preq2,
+        mock_get_offer,
         mock_sub_config_req,
         mock_wait_on_operation
     ):
@@ -119,7 +119,7 @@ class TestAzureCloudPartner(object):
                 'id': 'product/123456789'
             }]
         }
-        mock_preq2.return_value = doc
+        mock_get_offer.return_value = doc
         mock_sub_config_req.return_value = '123'
 
         self.image.add_image_to_offer(

--- a/tests/test_azure_container.py
+++ b/tests/test_azure_container.py
@@ -20,10 +20,10 @@ class TestAzureCcontainer(object):
     def inject_fixtures(self, caplog):
         self._caplog = caplog
 
-    @patch('azure_img_utils.azure_container.get_durable_id')
+    @patch('azure_img_utils.cloud_partner.get_durable_id')
     @patch('azure_img_utils.azure_container.acquire_access_token')
-    @patch('azure_img_utils.azure_container.get_resource_endpoint')
-    @patch('azure_img_utils.azure_container.process_request')
+    @patch('azure_img_utils.cloud_partner.get_resource_endpoint')
+    @patch('azure_img_utils.cloud_partner.process_request')
     def test_offer_exists(
         self,
         mock_process_request,


### PR DESCRIPTION
As this `get_offer` function is identical for container based products and images, I moved the function logic into the azure_container file to avoid duplicating the code.

Tests have been modified accordingly.