### PR TITLE
Update python versions in ci test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10", 3.11, 3.12]
+        python-version: [3.9, "3.10", 3.11, 3.12, 3.13]
 
     steps:
     - uses: actions/checkout@v2

--- a/python-azure-img-utils.spec
+++ b/python-azure-img-utils.spec
@@ -35,6 +35,7 @@ BuildRequires:  fdupes
 BuildRequires:  %{pythons}-msal
 BuildRequires:  %{pythons}-azure-identity
 BuildRequires:  %{pythons}-azure-mgmt-compute >= 26.1.0
+BuildRequires:  %{pythons}-azure-mgmt-compute < 36.0.0
 BuildRequires:  %{pythons}-azure-mgmt-storage
 BuildRequires:  %{pythons}-azure-storage-blob >= 12.0.1
 BuildRequires:  %{pythons}-requests
@@ -47,6 +48,7 @@ BuildRequires:  %{pythons}-wheel
 Requires:       %{pythons}-msal
 Requires:       %{pythons}-azure-identity
 Requires:       %{pythons}-azure-mgmt-compute >= 26.1.0
+Requires:       %{pythons}-azure-mgmt-compute < 36.0.0
 Requires:       %{pythons}-azure-mgmt-storage
 Requires:       %{pythons}-azure-storage-blob >= 12.0.1
 Requires:       %{pythons}-requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 click
 msal
 azure-identity
-azure-mgmt-compute>=26.1.0
+azure-mgmt-compute>=26.1.0,<36.0.0
 azure-mgmt-storage
 azure-storage-blob>=12.0.0
 requests


### PR DESCRIPTION
Add version restriction on azure management compute package to prevent update to version
with breaking changes.

This is a temporary restriction until package can be updated.